### PR TITLE
Prevent application from leaks

### DIFF
--- a/waveprogress/src/main/java/cn/fanrunqi/waveprogress/WaveProgressView.java
+++ b/waveprogress/src/main/java/cn/fanrunqi/waveprogress/WaveProgressView.java
@@ -124,21 +124,29 @@ public class WaveProgressView extends View {
         mTextPaint = new Paint();
         mTextPaint.setAntiAlias(true);
         mTextPaint.setTextAlign(Paint.Align.CENTER);
+    }
+    
+    @override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        handler.sendEmptyMessage(INVALIDATE);
+    }
 
-        handler.sendEmptyMessageDelayed(INVALIDATE, 100);
+    @override
+    protected void onDetachedFromWindow() {
+        handler.removeCallbacksAndMessages(null);
+        super.onDetachedFromWindow();
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
         mWidth = MeasureSpec.getSize(widthMeasureSpec);
         mCurY = mHeight = MeasureSpec.getSize(heightMeasureSpec);
     }
 
     @Override
     protected void onDraw(Canvas canvas) {
-
         if (mBackgroundBitmap != null) {
             canvas.drawBitmap(createImage(), 0, 0, null);
         }

--- a/waveprogress/src/main/java/cn/fanrunqi/waveprogress/WaveProgressView.java
+++ b/waveprogress/src/main/java/cn/fanrunqi/waveprogress/WaveProgressView.java
@@ -60,7 +60,6 @@ public class WaveProgressView extends View {
         }
     };
 
-
     public WaveProgressView(Context context) {
         this(context, null, 0);
     }
@@ -84,7 +83,6 @@ public class WaveProgressView extends View {
         this.mMaxProgress = maxProgress;
     }
 
-
     public void setText(String mTextColor, int mTextSize) {
         this.mTextColor = mTextColor;
         this.mTextSize = mTextSize;
@@ -94,7 +92,6 @@ public class WaveProgressView extends View {
         this.mWaveHeight = mWaveHight;
         this.mWaveHalfWidth = mWaveWidth / 2;
     }
-
 
     public void setWaveColor(String mWaveColor) {
         this.mWaveColor = mWaveColor;
@@ -126,16 +123,16 @@ public class WaveProgressView extends View {
         mTextPaint.setTextAlign(Paint.Align.CENTER);
     }
     
-    @override
+    @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         handler.sendEmptyMessage(INVALIDATE);
     }
 
-    @override
+    @Override
     protected void onDetachedFromWindow() {
-        handler.removeCallbacksAndMessages(null);
         super.onDetachedFromWindow();
+        handler.removeCallbacksAndMessages(null);
     }
 
     @Override


### PR DESCRIPTION
The app leaks because the handler is never removed.
Need to add the handler in onAttach, and remove the call from onDetach.